### PR TITLE
Update USE_NTP_TIME to use new format.

### DIFF
--- a/restAPI.ino
+++ b/restAPI.ino
@@ -352,7 +352,7 @@ void sendDeviceInfo()
     strlcat(compileOptions, "[USE_SYSLOGGER]", sizeof(compileOptions));
 #endif
 #ifdef USE_NTP_TIME
-    strlcat(compileOptions, sizeof(compileOptions), "[USE_NTP_TIME]");
+    strlcat(compileOptions, "[USE_NTP_TIME]", sizeof(compileOptions));
 #endif
 
   sendStartJsonObj("devinfo");


### PR DESCRIPTION
This fixes the compilation failure when this feature is enabled (PRE 4.0 meter)